### PR TITLE
Add Request component

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@kadira/react-storybook-addon-info": "^3.3.0",
     "@kadira/storybook": "^2.5.2",
+    "axios": "^0.15.3",
     "babel-cli": "^6.22.2",
     "babel-plugin-transform-class-properties": "^6.22.0",
     "babel-preset-latest": "^6.22.0",

--- a/src/components/Error/index.examples.js
+++ b/src/components/Error/index.examples.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import {storiesOf} from '@kadira/storybook'
+import {stringFixture} from '../../utils/Fixtures'
+import Error from './index'
+
+storiesOf('Error')
+
+  .addWithInfo('API', () => (
+    <Error>
+      {stringFixture}
+    </Error>
+  ))

--- a/src/components/Error/index.js
+++ b/src/components/Error/index.js
@@ -1,0 +1,13 @@
+import React, {PropTypes} from 'react'
+
+const Error = ({children}) => (
+  <div className='red'>
+    {children}
+  </div>
+)
+
+Error.propTypes = {
+  children: PropTypes.string.isRequired,
+}
+
+export default Error

--- a/src/components/Request/index.examples.js
+++ b/src/components/Request/index.examples.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import {map} from 'lodash'
+import {storiesOf} from '@kadira/storybook'
+import {apiFixture} from '../../utils/Fixtures'
+import Request from './index'
+
+const Comments = ({comments}) => (
+  <div>
+    {map(comments, (comment, index) => (
+      <div key={index}>
+        <div>By {comment.email}</div>
+        <div>{comment.body}</div>
+        <hr />
+      </div>
+    ))}
+  </div>
+)
+
+storiesOf('Request')
+
+  .addWithInfo('Automatic', () => (
+    <Request url={apiFixture}>
+      {({data}) => (
+        <Comments comments={data} />
+      )}
+    </Request>
+  ))
+
+  .addWithInfo('Lazy', () => (
+    <Request
+      lazy
+      method='get'
+      url={apiFixture}
+    >
+      {({request, data}) => data
+        ? <Comments comments={data} />
+        : <a onClick={() => request()}>
+            TAP TO VIEW COMMENTS
+          </a>
+      }
+    </Request>
+  ))

--- a/src/components/Request/index.js
+++ b/src/components/Request/index.js
@@ -1,0 +1,127 @@
+import React, {Component, PropTypes} from 'react'
+import axios from 'axios'
+import {isEqual, first} from 'lodash'
+import Loading from '../Loading'
+import Error from '../Error'
+
+const http = axios.create()
+
+const methods = [
+  'get',
+  'post',
+  'put',
+  'delete',
+]
+
+export default class Request extends Component {
+
+  static propTypes = {
+    url: PropTypes.string.isRequired,
+    method: PropTypes.oneOf(methods),
+    params: PropTypes.object,
+    headers: PropTypes.object,
+    body: PropTypes.object,
+    lazy: PropTypes.bool,
+    onResponse: PropTypes.func,
+    onData: PropTypes.func,
+    onError: PropTypes.func,
+    children: PropTypes.func,
+  }
+
+  static defaultProps = {
+    method: first(methods),
+  }
+
+  state = {
+    running: !this.props.lazy,
+    response: null,
+    data: null,
+    error: null,
+  }
+
+  componentDidMount() {
+    if (!this.props.lazy) {
+      this.request()
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!this.props.lazy && !isEqual(this.props, nextProps)) {
+      this.request()
+    }
+  }
+
+  componentWillUnmount() {
+    this.willUnmount = true
+  }
+
+  request = (body = this.props.body) => {
+    this.setState({request: true}, () => {
+      http.request({
+        method: this.props.method,
+        url: this.props.url,
+        params: this.props.params,
+        headers: this.props.headers,
+        data: body,
+      }).then(response => {
+        if (this.willUnmount) {
+          return
+        }
+        this.setState({
+          running: false,
+          response,
+          data: response.data,
+          error: null,
+        }, () => {
+          if (this.props.onResponse) {
+            this.props.onResponse(null, this.state.response)
+          }
+          if (this.props.onData) {
+            this.props.onData(this.state.data)
+          }
+        })
+      }).catch(error => {
+        if (this.willUnmount) {
+          return
+        }
+        this.setState({
+          running: false,
+          response: error,
+          error,
+        }, () => {
+          if (this.props.onResponse) {
+            this.props.onResponse(this.state.response)
+          }
+          if (this.props.onError) {
+            this.props.onError(this.state.error)
+          }
+        })
+      })
+    })
+  }
+
+  render() {
+    const {children} = this.props
+    const {running, error, data, response} = this.state
+    if (!children) {
+      return null
+    }
+    if (running) {
+      return <Loading />
+    }
+    if (error) {
+      return (
+        <Error>
+          Error: {error.message}
+        </Error>
+      )
+    }
+    return this.props.children({
+      request: this.request,
+      running,
+      error,
+      data,
+      response,
+    }) || null
+  }
+}

--- a/src/utils/Fixtures/index.js
+++ b/src/utils/Fixtures/index.js
@@ -8,6 +8,8 @@ export const urlFixture = 'https://google.com'
 
 export const avatarImageUrlFixture = 'http://placehold.it/150x150?text=A+image'
 
+export const apiFixture = 'http://jsonplaceholder.typicode.com/comments'
+
 export const ComponentFixture = () => (
   <div>
     A component

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,6 +358,12 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
+axios@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
+  dependencies:
+    follow-redirects "1.0.0"
+
 babel-cli@^6.22.2:
   version "6.22.2"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.22.2.tgz#3f814c8acf52759082b8fedd9627f938936ab559"
@@ -2589,6 +2595,12 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+follow-redirects@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
+  dependencies:
+    debug "^2.2.0"
 
 font-awesome@^4.6.3:
   version "4.7.0"


### PR DESCRIPTION
# Changes

- Add `Request` and `Error` components
- Add styleguide examples

`Request` is based on smalldots `Fetch` component, but with default loading and error handling and a few bug fixes. You can also wrap it in another render callback (function as child) component [to include headers/url patterns etc. like I do in the Instructor Center](https://github.com/eggheadio/egghead-instructor-center/blob/master/src/components/Request/index.js).

# Next Steps

@tayiorbeii @DrShpongle
- New version tested in another project - I'm using this all over in the instructor center, but I'd recommend testing it in your own project locally [using yarn/npm link before publishing a new version](https://egghead.io/lessons/javascript-test-npm-packages-locally-in-another-project-using-npm-link?course=create-javascript-packages-on-npm).
- New version published to npm; you may want to look into `np`; [I just uploaded an egghead lesson on it](https://egghead.io/lessons/javascript-update-published-npm-packages-with-np?course=create-javascript-packages-on-npm).

# Result For User

![request](https://cloud.githubusercontent.com/assets/5497885/22667391/cfe09548-ec79-11e6-9069-b065ec041eea.gif)

---

![](https://media.giphy.com/media/UDOJ2P4kSklAQ/giphy.gif)