### PR TITLE
Simplify workflow for continuous deployment on Codeship (resolve eggheadio/egghead-instructor-center#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # egghead-ui
 
 This repo has two purposes:
-- A component library, [pubished on npm](https://www.npmjs.com/package/egghead-ui)
 - A living style guide app with documentation, published on [styleguide.egghead.io](https://styleguide.egghead.io)
+- A component library, [pubished on npm](https://www.npmjs.com/package/egghead-ui)
 
 ---
 
@@ -30,21 +30,16 @@ View [the style guide](https://styleguide.egghead.io) for visual examples and co
 
 ## Workflow
 
-- checkout and pull latest from master
-- create feature branch and check it out
+- create feature branch off of master
 - `yarn` to install latest packages
 - `yarn dev:styleguide` to develop using the style guide
-- `yarn dev:library` to develop the library [with yarn link](https://yarnpkg.com/en/docs/cli/link)
+- `yarn dev:library` to develop the library
 - [localhost:2000](http://localhost:2000) to view the style guide
-- use [`yarn link`](https://yarnpkg.com/lang/en/docs/cli/link/) to test consuming components in another project
-- submit a pull request for your feature branch
-- continuous integration runs in Codeship to ensure builds succeed
-- once continuous integration passes and you have an approved review, merge the pull request into master
-- continuous deployment runs in Codeship and deploys the latest style guide app to [styleguide.egghead.io](https://styleguide.egghead.io)
-- checkout `release` and pull latest from master
-- run `yarn release` which will ask you some questions to bump the verison and publish the latest library [on npm](https://www.npmjs.com/package/egghead-ui)
-- merge release into master
-- Notify consumers to run `yarn upgrade egghead-ui` in their projects to get latest, with a list of changes
+- use [`yarn link`](https://yarnpkg.com/lang/en/docs/cli/link/) to test using library components in another project
+- submit a pull request for feature branch to master
+- once [continuous integration passes](https://app.codeship.com/projects/200238/configure_tests) and there is an approved review, merge the pull request
+- [continuous deployment runs in Codeship](https://app.codeship.com/projects/200238/deployment_branches/162272) and deploys the latest style guide app to [styleguide.egghead.io](https://styleguide.egghead.io) and then updates the library to a new version and publishes it [on npm](https://www.npmjs.com/package/egghead-ui)
+- notify consumers to run `yarn add egghead-ui@latest` in their projects to get latest, with a list of changes
 
 ## Folders and files
 


### PR DESCRIPTION
# Changes

- Simplify steps for working on this project

To go along with this, there is a new custom deployment script for running `yarn release` in Codeship for the project that runs after the styleguide release:
https://app.codeship.com/projects/200238/deployment_branches/162272

@tayiorbeii you need to add your npm token in place of `{taylorNpmToken}` in that script ^. You can get it from your `~/.npmrc`. We also need to test this; so, the next time you make make a PR for `egghead-ui`, merge it into master and then let's check Codeship to make sure the `yarn release --minor` step works, instead of doing the release stuff manually locally. I'm not sure if it will be able to push the new git tag and package.json verison bump to the github repo, with our protected master branch so we may have to figure something out for that.

# Result For User

Once we get it worked out, simpler releases for egghead-ui so once you merge a PR into `master`, that's it! No more manual release branch + yarn release antics.

---

![](https://media.giphy.com/media/l3vR5Sghh85EBCnhC/giphy.gif)