### PR TITLE
Add Paragraph typography

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "Official living style guide app and component library for egghead.io",
   "main": "lib/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "Official living style guide app and component library for egghead.io",
   "main": "lib/index.js",
   "engines": {

--- a/src/components/Paragraph/index.examples.js
+++ b/src/components/Paragraph/index.examples.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import {storiesOf} from '@kadira/storybook'
+import {stringFixture} from '../../utils/Fixtures'
+import Paragraph, {types} from '.'
+
+const decoratorClasses = 'min-vh-100 bg-navy'
+
+storiesOf('Paragraph')
+
+  .addDecorator((story) => (<div className={decoratorClasses}>{story()}</div>))
+
+  .addWithInfo('Default', () => (
+    <Paragraph>{stringFixture}</Paragraph>
+  ))
+
+  .addWithPropsCombinations('Variations', Paragraph, {
+    children: [stringFixture],
+    type: types,
+  })

--- a/src/components/Paragraph/index.examples.js
+++ b/src/components/Paragraph/index.examples.js
@@ -3,7 +3,7 @@ import {storiesOf} from '@kadira/storybook'
 import {stringFixture} from '../../utils/Fixtures'
 import Paragraph, {types} from '.'
 
-const decoratorClasses = 'bg-navy pa3 h-100 min-vh-100'
+const decoratorClasses = 'bg-navy pa3 h-100 min-vh-100 gray'
 
 storiesOf('Paragraph')
 

--- a/src/components/Paragraph/index.examples.js
+++ b/src/components/Paragraph/index.examples.js
@@ -3,15 +3,11 @@ import {storiesOf} from '@kadira/storybook'
 import {stringFixture} from '../../utils/Fixtures'
 import Paragraph, {types} from '.'
 
-const decoratorClasses = 'min-vh-100 bg-navy'
+const decoratorClasses = 'bg-navy pa3 h-100 min-vh-100'
 
 storiesOf('Paragraph')
 
   .addDecorator((story) => (<div className={decoratorClasses}>{story()}</div>))
-
-  .addWithInfo('Default', () => (
-    <Paragraph>{stringFixture}</Paragraph>
-  ))
 
   .addWithPropsCombinations('Variations', Paragraph, {
     children: [stringFixture],

--- a/src/components/Paragraph/index.js
+++ b/src/components/Paragraph/index.js
@@ -1,0 +1,24 @@
+import React, {PropTypes} from 'react'
+import {keys, first} from 'lodash'
+
+const sharedClassName = 'sans-serif white'
+
+const classNameByType = {
+  default: 'f5',
+  small: 'f6',
+}
+
+export const types = keys(classNameByType)
+
+const Paragraph = ({children, type = first(types)}) => (
+  <p className={`${sharedClassName} ${classNameByType[type]}`}>
+    {children}
+  </p>
+)
+
+Paragraph.propTypes = {
+  children: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(types),
+}
+
+export default Paragraph

--- a/src/components/Paragraph/index.js
+++ b/src/components/Paragraph/index.js
@@ -10,7 +10,10 @@ const classNameByType = {
 
 export const types = keys(classNameByType)
 
-const Paragraph = ({children, type = first(types)}) => (
+const Paragraph = ({
+  children,
+  type = first(types),
+}) => (
   <p className={`${sharedClassName} ${classNameByType[type]}`}>
     {children}
   </p>


### PR DESCRIPTION
# Changes

- Add `Paragraph` component from latest Zeplin mocks

Using this as a test for the new Travis CI workflow as well.

# Result For User

![image](https://cloud.githubusercontent.com/assets/5497885/23284730/4ef7eda4-f9ea-11e6-85a9-fcbe7f2c05ea.png)

---

![](https://media.giphy.com/media/pxskMFZ3Q1uAU/giphy.gif)