### PR TITLE
Fix compile error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "Official living style guide app and component library for egghead.io",
   "main": "lib/index.js",
   "engines": {

--- a/src/utils/Card/index.js
+++ b/src/utils/Card/index.js
@@ -7,7 +7,7 @@ import { PlaylistMeta, PlaylistHeader } from '../../components/PlaylistCard'
 import Playlist from '../Playlist/'
 import { buildPlaylistMeta } from '../Playlist'
 import { secondsToString } from '../Time'
-import lessonJSON from '../lessonJSON' 
+import lessonJSON from './lessonJSON' 
 
 const commonCardClasses = 'relative'
 const commonInnerClasses = 'flex flex-column items-center bg-white navy relative z-1 br2'


### PR DESCRIPTION
# Changes

- Fixed one more compile error found from consuming latest 2.20.0 in instructor center; granted I should have tried this with yarn link before pushing, but I'm confused why `yarn verify` isn't catching build errors like this - they should be reported by the babel process in `yarn build:styleguide` and `yarn build:library` which are both run with `yarn verify`. @tayiorbeii maybe if you get some time you could look into this?
- Version bump for new npm release of library

# Result For User

No more compile errors.

---

![](https://media.giphy.com/media/13m2KN5OWxBTqM/giphy.gif)