### PR TITLE
Fix request onerror

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Official living style guide app and component library for egghead.io",
   "main": "lib/index.js",
   "engines": {

--- a/src/components/Request/index.js
+++ b/src/components/Request/index.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react'
 import axios from 'axios'
 import {isEqual, first} from 'lodash'
-import {Error} from '../Error'
+import Error from '../Error'
 import Loading from './components/Loading'
 
 const http = axios.create()
@@ -63,40 +63,42 @@ export default class Request extends Component {
         params: this.props.params,
         headers: this.props.headers,
         data: body,
-      }).then(response => {
-        if (this.willUnmount) {
-          return
-        }
-        this.setState({
-          running: false,
-          response,
-          data: response.data,
-          error: null,
-        }, () => {
-          if (this.props.onResponse) {
-            this.props.onResponse(null, this.state.response)
-          }
-          if (this.props.onData) {
-            this.props.onData(this.state.data)
-          }
-        })
-      }).catch(error => {
-        if (this.willUnmount) {
-          return
-        }
-        this.setState({
-          running: false,
-          response: error,
-          error,
-        }, () => {
-          if (this.props.onResponse) {
-            this.props.onResponse(this.state.response)
-          }
-          if (this.props.onError) {
-            this.props.onError(this.state.error)
-          }
-        })
       })
+        .then(response => {
+          if (this.willUnmount) {
+            return
+          }
+          this.setState({
+            running: false,
+            response,
+            data: response.data,
+            error: null,
+          }, () => {
+            if (this.props.onResponse) {
+              this.props.onResponse(null, this.state.response)
+            }
+            if (this.props.onData) {
+              this.props.onData(this.state.data)
+            }
+          })
+        })
+        .catch(error => {
+          if (this.willUnmount) {
+            return
+          }
+          this.setState({
+            running: false,
+            response: error,
+            error,
+          }, () => {
+            if (this.props.onResponse) {
+              this.props.onResponse(this.state.response)
+            }
+            if (this.props.onError) {
+              this.props.onError(this.state.error)
+            }
+          })
+        })
     })
   }
 
@@ -112,7 +114,7 @@ export default class Request extends Component {
     if (error) {
       return (
         <Error>
-          Error: {error.message}
+          {`Error: ${error.message}`}
         </Error>
       )
     }


### PR DESCRIPTION
# Changes

- Fix Error rendering when Request fails
- Bump version for new library release

# Result For User

Errors messages are now shown when an error occurs with a request and `error` is passed up to `onError` correctly.

---

![](https://media.giphy.com/media/xTk9ZH5U5vb76JhNHa/giphy.gif)