### PR TITLE
Add Pill Button Variants, Refactor for Colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "Official living style guide app and component library for egghead.io",
   "main": "lib/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-preset-latest": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "eslint": "^3.16.1",
+    "eslint-config-keystone": "^3.0.0",
     "font-awesome": "^4.6.3",
     "lodash": "^4.16.2",
     "pre-commit": "^1.2.2",

--- a/src/components/Button/index.examples.js
+++ b/src/components/Button/index.examples.js
@@ -82,6 +82,13 @@ storiesOf('Button')
           </div>
         )
       })}
+
+      <div className='mb2 mh2'>
+        <Button type='pill' outline play>
+          Play Course
+        </Button>
+      </div>
+
     </div>
   ))
 

--- a/src/components/Button/index.examples.js
+++ b/src/components/Button/index.examples.js
@@ -4,13 +4,13 @@ import {clickHandlerFixture} from '../../utils/Fixtures'
 import Button from '.'
 
 const standardButtonExamples = [
-  {type: 'default', children: 'Default'},
-  {type: 'primary', children: 'Primary'},
-  {type: 'success', children: 'Success'},
-  {type: 'warning', children: 'Warning'},
-  {type: 'danger', children: 'Danger'},
-  {type: 'orange', children: 'Orange'},
-  {type: 'turquoise', children: 'turquoise'}
+  {color: 'white', children: 'White'},
+  {color: 'blue', children: 'Blue'},
+  {color: 'green', children: 'Green'},
+  {color: 'yellow', children: 'Yellow'},
+  {color: 'red', children: 'Red'},
+  {color: 'orange', children: 'Orange'},
+  {color: 'turquoise', children: 'Turquoise'}
 ]
 
 const decoratorClasses = 'flex flex-column content-center justify-around flex-wrap items-center vh-100 bg-navy'
@@ -25,7 +25,7 @@ storiesOf('Button')
       <div className={btnDisp}>
         {standardButtonExamples.map((btn, i) => {
           return (
-            <Button type={btn.type} onClick={clickHandlerFixture} key={i}>
+            <Button color={btn.color} onClick={clickHandlerFixture} key={i}>
               {btn.children}
             </Button>
           )
@@ -43,8 +43,8 @@ storiesOf('Button')
       <div className={btnDisp}>
         {standardButtonExamples.map((btn, i) => {
           return (
-            <Button type={btn.type.toLowerCase()} size='small' onClick={clickHandlerFixture} key={i}>
-              {btn.type}
+            <Button color={btn.color.toLowerCase()} size='small' onClick={clickHandlerFixture} key={i}>
+              {btn.color}
             </Button>
           )
         })}
@@ -60,8 +60,8 @@ storiesOf('Button')
       <div className={btnDisp}>
         {standardButtonExamples.map((btn, i) => {
           return (
-            <Button type={btn.type.toLowerCase()} size='extra-large' onClick={clickHandlerFixture} key={i}>
-              {btn.type}
+            <Button color={btn.color.toLowerCase()} size='extra-large' onClick={clickHandlerFixture} key={i}>
+              {btn.color}
             </Button>
           )
         })}
@@ -77,8 +77,8 @@ storiesOf('Button')
       {standardButtonExamples.map((btn, i) => {
         return (
           <div className='mb2 mh2' key={i}>
-            <Button type={btn.type.toLowerCase()} outline onClick={clickHandlerFixture} key={i}>
-              {btn.type}
+            <Button color={btn.color.toLowerCase()} outline onClick={clickHandlerFixture} key={i}>
+              {btn.color}
             </Button>
           </div>
         )
@@ -94,15 +94,15 @@ storiesOf('Button')
       {standardButtonExamples.map((btn, i) => {
         return (
           <div className='mb2 mh2' key={i}>
-            <Button type={btn.type.toLowerCase()} pill outline onClick={clickHandlerFixture} key={i}>
-              {btn.type}
+            <Button color={btn.color.toLowerCase()} pill outline onClick={clickHandlerFixture} key={i}>
+              {btn.color}
             </Button>
           </div>
         )
       })}
 
       <div className='mb2 mh2'>
-        <Button type='orange' pill outline play>
+        <Button color='orange' pill outline play>
           Play Course
         </Button>
       </div>

--- a/src/components/Button/index.examples.js
+++ b/src/components/Button/index.examples.js
@@ -9,7 +9,8 @@ const standardButtonExamples = [
   {type: 'success', children: 'Success'},
   {type: 'warning', children: 'Warning'},
   {type: 'danger', children: 'Danger'},
-  {type: 'pill', children: 'Pill'}
+  {type: 'orange', children: 'Orange'},
+  {type: 'turquoise', children: 'turquoise'}
 ]
 
 const decoratorClasses = 'flex flex-column content-center justify-around flex-wrap items-center vh-100 bg-navy'
@@ -84,7 +85,7 @@ storiesOf('Button')
       })}
 
       <div className='mb2 mh2'>
-        <Button type='pill' outline play>
+        <Button type='orange' pill outline play>
           Play Course
         </Button>
       </div>

--- a/src/components/Button/index.examples.js
+++ b/src/components/Button/index.examples.js
@@ -8,13 +8,12 @@ const standardButtonExamples = [
   {type: 'primary', children: 'Primary'},
   {type: 'success', children: 'Success'},
   {type: 'warning', children: 'Warning'},
-  {type: 'danger', children: 'Danger'}
+  {type: 'danger', children: 'Danger'},
+  {type: 'pill', children: 'Pill'}
 ]
-
 
 const decoratorClasses = 'flex flex-column content-center justify-around flex-wrap items-center vh-100 bg-navy'
 const btnDisp = 'flex flex-column justify-around items-center vh-100'
-
 
 // Standard Large Button (Default)
 storiesOf('Button')
@@ -68,7 +67,6 @@ storiesOf('Button')
       </div>
     )
   )
-
 
 // Outline Button
 storiesOf('Button')

--- a/src/components/Button/index.examples.js
+++ b/src/components/Button/index.examples.js
@@ -83,6 +83,23 @@ storiesOf('Button')
           </div>
         )
       })}
+    </div>
+  ))
+
+// Outline Pill Button
+storiesOf('Button')
+  .addDecorator((story) => (<div className={decoratorClasses}>{story()}</div>))
+  .addWithInfo('Pill Outline (All Sizes)', `The Outline Button is available in all sizes (pictured in Large).`, () => (
+    <div className={btnDisp}>
+      {standardButtonExamples.map((btn, i) => {
+        return (
+          <div className='mb2 mh2' key={i}>
+            <Button type={btn.type.toLowerCase()} pill outline onClick={clickHandlerFixture} key={i}>
+              {btn.type}
+            </Button>
+          </div>
+        )
+      })}
 
       <div className='mb2 mh2'>
         <Button type='orange' pill outline play>

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -5,7 +5,7 @@ import Icon from '../Icon'
 const commonClasses = 'link dib f5 fw6 tracked tc br2 ttu ba pointer'
 
 const sizes = ['large', 'small', 'extra-large']
-const types = ['success', 'warning', 'danger', 'primary', 'default', 'orange', 'turquoise']
+const colors = ['green', 'yellow', 'red', 'blue', 'white', 'orange', 'turquoise']
 
 const sizedBtnClasses = {
   'large': 'pa3',
@@ -14,21 +14,21 @@ const sizedBtnClasses = {
 }
 
 const solidBtnClasses = {
-  success: 'b--transparent bg-green dark-navy hover-bg-dark-green',
-  warning: 'b--transparent bg-yellow dark-navy hover-bg-orange hover-white',
-  danger: 'b--red bg-red white hover-b--dark-red hover-bg-dark-red',
-  primary: 'b--transparent bg-blue white hover-bg-dark-blue',
-  default: 'b--white bg-white dark-navy hover-bg-light-gray',
+  green: 'b--transparent bg-green dark-navy hover-bg-dark-green',
+  yellow: 'b--transparent bg-yellow dark-navy hover-bg-orange hover-white',
+  red: 'b--red bg-red white hover-b--dark-red hover-bg-dark-red',
+  blue: 'b--transparent bg-blue white hover-bg-dark-blue',
+  white: 'b--white bg-white dark-navy hover-bg-light-gray',
   orange: 'b--orange bg-orange bw1 navy',
   turquoise: 'b--turquoise bg-turquoise bw1 navy'
 }
 
 const outlineBtnClasses = {
-  success: 'b--green green bg-transparent hover-dark-navy hover-bg-green',
-  warning: 'b--yellow yellow bg-transparent hover-dark-navy hover-bg-yellow',
-  danger: 'b--red red bg-transparent hover-dark-navy hover-bg-red',
-  primary: 'b--blue blue bg-transparent white hover-bg-dark-blue',
-  default: 'b--white white bg-transparent hover-dark-navy hover-bg-white',
+  green: 'b--green green bg-transparent hover-dark-navy hover-bg-green',
+  yellow: 'b--yellow yellow bg-transparent hover-dark-navy hover-bg-yellow',
+  red: 'b--red red bg-transparent hover-dark-navy hover-bg-red',
+  blue: 'b--blue blue bg-transparent white hover-bg-dark-blue',
+  white: 'b--white white bg-transparent hover-dark-navy hover-bg-white',
   orange: 'b--orange orange bg-transparent hover-dark-navy hover-bg-orange bw1',
   turquoise: 'b--turquoise turquoise bg-transparent hover-dark-navy hover-bg-turquoise bw1'
 }
@@ -43,8 +43,8 @@ const styleMap = (size) => {
   return size === undefined ? classes['large'] : classes[size]
 }
 
-const Button = styled(({href, type = 'default', size = 'large', outline = false, children, className, pill = false, play = false, onClick}) => {
-  const btnClasses = outline ? outlineBtnClasses[type] : solidBtnClasses[type]
+const Button = styled(({href, color = 'white', size = 'large', outline = false, children, className, pill = false, play = false, onClick}) => {
+  const btnClasses = outline ? outlineBtnClasses[color] : solidBtnClasses[color]
   const sizeClasses = sizedBtnClasses[size]
 
   return (
@@ -57,7 +57,7 @@ const Button = styled(({href, type = 'default', size = 'large', outline = false,
 Button.propTypes = {
   href: PropTypes.string,
   onClick: PropTypes.func,
-  type: PropTypes.oneOf(types),
+  color: PropTypes.oneOf(colors),
   size: PropTypes.oneOf(sizes),
   outline: PropTypes.bool,
   children: PropTypes.string.isRequired

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import styled from 'styled-components'
+import Icon from '../Icon'
 
 const commonClasses = 'link dib f5 fw6 tracked tc br2 ttu ba pointer'
 
@@ -27,7 +28,7 @@ const outlineBtnClasses = {
   danger: 'b--red red bg-transparent hover-dark-navy hover-bg-red',
   primary: 'b--blue blue bg-transparent white hover-bg-dark-blue',
   default: 'b--white white bg-transparent hover-dark-navy hover-bg-white',
-  pill: 'b--orange orange bg-transparent br-pill bw1 navy'
+  pill: 'b--orange orange bg-transparent hover-dark-navy hover-bg-orange br-pill bw1'
 }
 
 const styleMap = (size) => {
@@ -40,13 +41,13 @@ const styleMap = (size) => {
   return size === undefined ? classes['large'] : classes[size]
 }
 
-const Button = styled(({href, type = 'default', size = 'large', outline = false, children, className, onClick}) => {
+const Button = styled(({href, type = 'default', size = 'large', outline = false, children, className, play = false, onClick}) => {
   const btnClasses = outline ? outlineBtnClasses[type] : solidBtnClasses[type]
   const sizeClasses = sizedBtnClasses[size]
 
   return (
     <button href={href} className={`${commonClasses} ${btnClasses} ${sizeClasses} ${className}`} onClick={onClick}>
-      {children}
+      {play ? <Icon type='play' className='mr2' /> : ''} {children}
     </button>
   )
 })`${props => styleMap(props.size)}`

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -17,7 +17,8 @@ const solidBtnClasses = {
   warning: 'b--transparent bg-yellow dark-navy hover-bg-orange hover-white',
   danger: 'b--red bg-red white hover-b--dark-red hover-bg-dark-red',
   primary: 'b--transparent bg-blue white hover-bg-dark-blue',
-  default: 'b--white bg-white dark-navy hover-bg-light-gray'
+  default: 'b--white bg-white dark-navy hover-bg-light-gray',
+  pill: 'b--orange bg-orange br-pill bw1 navy'
 }
 
 const outlineBtnClasses = {
@@ -25,7 +26,8 @@ const outlineBtnClasses = {
   warning: 'b--yellow yellow bg-transparent hover-dark-navy hover-bg-yellow',
   danger: 'b--red red bg-transparent hover-dark-navy hover-bg-red',
   primary: 'b--blue blue bg-transparent white hover-bg-dark-blue',
-  default: 'b--white white bg-transparent hover-dark-navy hover-bg-white'
+  default: 'b--white white bg-transparent hover-dark-navy hover-bg-white',
+  pill: 'b--orange orange bg-transparent br-pill bw1 navy'
 }
 
 const styleMap = (size) => {
@@ -38,15 +40,15 @@ const styleMap = (size) => {
   return size === undefined ? classes['large'] : classes[size]
 }
 
-const Button = styled(({href, type='default', size='large', outline=false, children, className, onClick}) => {
-    const btnClasses = outline ? outlineBtnClasses[type] : solidBtnClasses[type]
-    const sizeClasses = sizedBtnClasses[size]
+const Button = styled(({href, type = 'default', size = 'large', outline = false, children, className, onClick}) => {
+  const btnClasses = outline ? outlineBtnClasses[type] : solidBtnClasses[type]
+  const sizeClasses = sizedBtnClasses[size]
 
-    return (
-      <button href={href} className={`${commonClasses} ${btnClasses} ${sizeClasses} ${className}`} onClick={onClick}>
-        {children}
-      </button>
-    )
+  return (
+    <button href={href} className={`${commonClasses} ${btnClasses} ${sizeClasses} ${className}`} onClick={onClick}>
+      {children}
+    </button>
+  )
 })`${props => styleMap(props.size)}`
 
 Button.propTypes = {

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -5,7 +5,7 @@ import Icon from '../Icon'
 const commonClasses = 'link dib f5 fw6 tracked tc br2 ttu ba pointer'
 
 const sizes = ['large', 'small', 'extra-large']
-const types = ['success', 'warning', 'danger', 'primary', 'default']
+const types = ['success', 'warning', 'danger', 'primary', 'default', 'orange', 'turquoise']
 
 const sizedBtnClasses = {
   'large': 'pa3',
@@ -19,7 +19,8 @@ const solidBtnClasses = {
   danger: 'b--red bg-red white hover-b--dark-red hover-bg-dark-red',
   primary: 'b--transparent bg-blue white hover-bg-dark-blue',
   default: 'b--white bg-white dark-navy hover-bg-light-gray',
-  pill: 'b--orange bg-orange br-pill bw1 navy'
+  orange: 'b--orange bg-orange bw1 navy',
+  turquoise: 'b--turquoise bg-turquoise bw1 navy'
 }
 
 const outlineBtnClasses = {
@@ -28,7 +29,8 @@ const outlineBtnClasses = {
   danger: 'b--red red bg-transparent hover-dark-navy hover-bg-red',
   primary: 'b--blue blue bg-transparent white hover-bg-dark-blue',
   default: 'b--white white bg-transparent hover-dark-navy hover-bg-white',
-  pill: 'b--orange orange bg-transparent hover-dark-navy hover-bg-orange br-pill bw1'
+  orange: 'b--orange orange bg-transparent hover-dark-navy hover-bg-orange bw1',
+  turquoise: 'b--turquoise turquoise bg-transparent hover-dark-navy hover-bg-turquoise bw1'
 }
 
 const styleMap = (size) => {
@@ -41,12 +43,12 @@ const styleMap = (size) => {
   return size === undefined ? classes['large'] : classes[size]
 }
 
-const Button = styled(({href, type = 'default', size = 'large', outline = false, children, className, play = false, onClick}) => {
+const Button = styled(({href, type = 'default', size = 'large', outline = false, children, className, pill = false, play = false, onClick}) => {
   const btnClasses = outline ? outlineBtnClasses[type] : solidBtnClasses[type]
   const sizeClasses = sizedBtnClasses[size]
 
   return (
-    <button href={href} className={`${commonClasses} ${btnClasses} ${sizeClasses} ${className}`} onClick={onClick}>
+    <button href={href} className={`${commonClasses} ${btnClasses} ${sizeClasses} ${className} ${pill ? 'br-pill' : ''}`} onClick={onClick}>
       {play ? <Icon type='play' className='mr2' /> : ''} {children}
     </button>
   )

--- a/src/components/Icon/index.examples.js
+++ b/src/components/Icon/index.examples.js
@@ -39,9 +39,9 @@ storiesOf('Icons')
   .addWithInfo('Box (Checked)', () => (
     <Icon type='box-check' />
   ))
-  
+
   .addWithInfo('Check', () => (
-    <Icon type='check' />    
+    <Icon type='check' />
   ))
 
   .addWithInfo('Close', () => (
@@ -70,8 +70,14 @@ storiesOf('Icons')
 
   .addWithInfo('Refresh', () => (
     <Icon
-      type='refresh' 
+      type='refresh'
       spin
+    />
+  ))
+
+  .addWithInfo('Play', () => (
+    <Icon
+      type='play'
     />
   ))
 

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -7,7 +7,7 @@ export const sizes = {
   3: 'fa-2x',
   4: 'fa-3x',
   5: 'fa-4x',
-  6: 'fa-5x',
+  6: 'fa-5x'
 }
 
 export const types = {
@@ -24,6 +24,7 @@ export const types = {
   'lesson': 'file-o',
   'menu': 'bars',
   'more-info': 'info-circle',
+  'play': 'play',
   'question': 'question-circle',
   'refresh': 'refresh',
   'remove': 'minus-circle',
@@ -42,7 +43,9 @@ export const colors = {
   'primary': 'blue',
   'warning': 'yellow',
   'danger': 'red',
-  'light': 'light-gray'
+  'light': 'light-gray',
+  'orange': 'orange',
+  'turquoise': 'turquoise'
 }
 
 const Icon = ({
@@ -50,7 +53,7 @@ const Icon = ({
   size,
   color,
   spin,
-  className,
+  className
 }) => (
   <span className={`
     fa
@@ -67,12 +70,12 @@ Icon.propTypes = {
   size: PropTypes.oneOf(keys(sizes)),
   color: PropTypes.oneOf(keys(colors)),
   spin: PropTypes.bool,
-  className:  PropTypes.string,
+  className: PropTypes.string
 }
 
 Icon.defaultProps = {
   size: '1',
-  spin: false,
+  spin: false
 }
 
 export default Icon

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,6 +2291,10 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-config-keystone@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-keystone/-/eslint-config-keystone-3.0.0.tgz#28d6323491a95cc738613c0ac2a7b73936eb5332"
+
 eslint-config-react-app@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-0.5.0.tgz#68c6da07d1cfbce6a992bc244ba16186b942d89f"


### PR DESCRIPTION
All colors:
![image](https://cloud.githubusercontent.com/assets/2262858/23572924/c68f4f1a-002f-11e7-8ffc-83bafc8baed4.png)

Pill variant:
![image](https://cloud.githubusercontent.com/assets/2262858/23572938/d7582be6-002f-11e7-91aa-1961fe4cdc5a.png)

* Refactor semantic to color: (`type='danger'` is now `color='red'`)
* Adds Pill Button Variants
* Adds `Play` Icon
* Adds turquoise and orange `Icon` colors
* Lint fixes

![](http://fridayatfive.com/dr%20mario%20gif.gif)