### PR TITLE
Add secure example endpoint to work on styleguide.egghead.io

### DIFF
--- a/src/components/Request/index.examples.js
+++ b/src/components/Request/index.examples.js
@@ -3,6 +3,12 @@ import {storiesOf} from '@kadira/storybook'
 import {apiFixture} from '../../utils/fixtures'
 import Request from '.'
 
+const ExampleDataRender = ({items}) => (
+  <div>
+    There are {items.length} items in the example data. See dev tools network tab.
+  </div>
+)
+
 storiesOf('Request')
   .addWithInfo(
     'Info',
@@ -10,9 +16,7 @@ storiesOf('Request')
     () => (
       <Request url={apiFixture}>
         {({data}) => (
-          <div>
-            {JSON.stringify(data)}
-          </div>
+          <ExampleDataRender items={data} />
         )}
       </Request>
     ),
@@ -23,16 +27,12 @@ storiesOf('Request')
       <div>
         <Request url={apiFixture}>
           {({data}) => (
-            <div>
-              {JSON.stringify(data)}
-            </div>
+            <ExampleDataRender items={data} />
           )}
         </Request>
         <Request url='/error'>
           {({data}) => (
-            <div>
-              {JSON.stringify(data)}
-            </div>
+            <ExampleDataRender items={data} />
           )}
         </Request>
         <Request
@@ -41,9 +41,7 @@ storiesOf('Request')
           url={apiFixture}
         >
           {({request, data}) => data
-            ? <div>
-                {JSON.stringify(data)}
-              </div>
+            ? <ExampleDataRender items={data} />
             : <a onClick={() => request()}>
                 Tap to request data
               </a>

--- a/src/utils/fixtures.js
+++ b/src/utils/fixtures.js
@@ -8,7 +8,7 @@ export const urlFixture = 'https://google.com'
 
 export const avatarImageUrlFixture = 'http://placehold.it/150x150?text=A+image'
 
-export const apiFixture = 'http://www.fakeresponse.com/api/?sleep=2'
+export const apiFixture = 'https://jsonplaceholder.typicode.com/photos'
 
 export const eventHandlerFixture = () => {
   alert('Event handler was called')


### PR DESCRIPTION
# Changes

- Needed https fake endpoint for https://styleguide.egghead.io Request examples to work

# Result For User

Shows request examples; automatic, error, lazy, loading state
![image](https://cloud.githubusercontent.com/assets/5497885/23725731/ead27388-040e-11e7-904f-87f9c6f66b7d.png)

---

![](https://media.giphy.com/media/14c0YMK7oEVs0o/giphy.gif)