### PR TITLE
Add light background support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,11 @@ deploy:
       tags: true
       branch: master
 notifications:
-  slack: $SLACK_INTEGRATION_TOKEN
+  email:
+    on_success: never
+    on_failure: always
+  slack:
+    on_success: never
+    on_failure: always
+    rooms:
+      secure: LnEL+23Jv8ts6tufKfvKoRT81c8xvEOd+ZvErqmgXPIb5HG525eudD8WaOsAF1XKxSq74JRRYp9y5jSC6/r3TDBDsRNV9sW4U/0/peLnSF/yzBII+W2JEUFe9RdLNrVSMxQRfvBesl3QlHRxOJ1Jhz4QYaPAodsTqDPUrUiW6QA=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "3.0.2",
+  "version": "3.1.2",
   "description": "Official living style guide app and component library for egghead.io",
   "homepage": "https://github.com/eggheadio/egghead-ui#readme",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "prepublish": "yarn build:library",
     "start": "react-scripts start"
   },
-  "pre-commit": [
-    "verify"
-  ],
   "babel": {
     "presets": [
       "babel-preset-react",
@@ -43,7 +40,6 @@
     "babel-preset-react": "^6.22.0",
     "eslint": "^3.16.1",
     "lodash": "^4.16.2",
-    "pre-commit": "^1.2.2",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-icons": "^2.2.3",

--- a/src/components/Heading/index.js
+++ b/src/components/Heading/index.js
@@ -21,7 +21,7 @@ const Heading = ({children, level}) => {
       </h3>
     ),
     4: (
-      <h4 className='mt0 bold f4 mb2'>
+      <h4 className='mt0 normal f4 mb2'>
         {children}
       </h4>
     ),

--- a/src/components/Paragraph/index.js
+++ b/src/components/Paragraph/index.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react'
 import {keys, first} from 'lodash'
 
-const sharedClassName = 'sans-serif white'
+const sharedClassName = 'sans-serif'
 
 const classNameByType = {
   medium: 'f5',

--- a/src/components/Request/components/Loading/index.js
+++ b/src/components/Request/components/Loading/index.js
@@ -16,12 +16,12 @@ const Rotate = styled.div`
 `;
 
 const Loading = () => (
-  <div className='mv3 white flex items-center'>
+  <div className='mv3 gray flex items-center'>
     <div className='mr2'>
       <Rotate>
         <Icon 
           type='refresh'
-          color='white'
+          color='gray'
         />
       </Rotate>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,7 +1691,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6, concat-stream@^1.4.7:
+concat-stream@^1.4.6:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1787,14 +1787,6 @@ cross-spawn@4.0.2:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
-    which "^1.2.9"
-
-cross-spawn@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  dependencies:
-    lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -4470,10 +4462,6 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-shim@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
-
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -4891,14 +4879,6 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     js-base64 "^2.1.9"
     source-map "^0.5.6"
     supports-color "^3.2.3"
-
-pre-commit@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
-  dependencies:
-    cross-spawn "^5.0.1"
-    spawn-sync "^1.0.15"
-    which "1.2.x"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -5627,12 +5607,6 @@ shallowequal@0.2.x, shallowequal@^0.2.2:
   dependencies:
     lodash.keys "^3.1.2"
 
-shebang-command@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  dependencies:
-    shebang-regex "^1.0.0"
-
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
@@ -5724,13 +5698,6 @@ source-map@~0.2.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
   dependencies:
     amdefine ">=0.0.4"
-
-spawn-sync@^1.0.15:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
-  dependencies:
-    concat-stream "^1.4.7"
-    os-shim "^0.1.2"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -6601,7 +6568,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@1.2.x, which@^1.0.5, which@^1.1.1, which@^1.2.9:
+which@^1.0.5, which@^1.1.1, which@^1.2.9:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:


### PR DESCRIPTION
# Changes

- Let font colors cascade
- Make loading icon color gray to work on light or dark backgrounds
- Remove pre-commit hook
- Fix heading 4 font weight
- Fix slack notifications; send to slack and email only on failure

---

![](https://media.giphy.com/media/11MS2pksWxB8SA/giphy.gif)