### PR TITLE
Remove padding from loading

### DIFF
--- a/src/components/Request/components/Loading/index.js
+++ b/src/components/Request/components/Loading/index.js
@@ -16,7 +16,7 @@ const Rotate = styled.div`
 `;
 
 const Loading = () => (
-  <div className='pa4 gray flex items-center'>
+  <div className='gray flex items-center'>
     <div className='mr2'>
       <Rotate>
         <Icon 


### PR DESCRIPTION
Gets rid of the side effect that can cause layout problems when used in lazy buttons and other situations. Better to wrap with padding when needed.