### PR TITLE
Remove reset now in tachyons-base and remove top margin from paragraphs

### DIFF
--- a/src/components/Paragraph/index.js
+++ b/src/components/Paragraph/index.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react'
 import {keys, first} from 'lodash'
 
-const sharedClassName = 'sans-serif'
+const sharedClassName = 'mt0'
 
 const classNameByType = {
   medium: 'f5',


### PR DESCRIPTION
Font families are now reset in tachyons-base v1.3.0 so setting it manually isn't needed. Also removing the top margin on paragraphs because paragraphs are better without the side effect; can add a wrapper where needed instead.