### PR TITLE
Fix request jitters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Official living style guide app and component library for egghead.io",
   "homepage": "https://github.com/eggheadio/egghead-ui#readme",
   "main": "lib/index.js",

--- a/src/components/Request/index.js
+++ b/src/components/Request/index.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react'
 import axios from 'axios'
-import {isEqual, first} from 'lodash'
+import {first} from 'lodash'
 import Error from '../Error'
 import Loading from './components/Loading'
 
@@ -24,12 +24,6 @@ export default class Request extends Component {
 
   componentDidMount() {
     if (!this.props.lazy) {
-      this.request()
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (!this.props.lazy && !isEqual(this.props, nextProps)) {
       this.request()
     }
   }


### PR DESCRIPTION
# Changes

- Request was needlessly re-calling the `request` method whenever `nextProps` and `this.props` were not exactly equal; this should not be the case. If `lazy` is used, the consumer has full control of calling `request`, and when `lazy` is absent, `request` should only be called once automatically; so `componentWillReceiveProps` was causing problems and not needed.

# Result For User

No more flashing "Loading" and tons of extra useless requests.

---

![](https://media.giphy.com/media/14aUO0Mf7dWDXW/giphy.gif)