### PR TITLE
Client side updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "3.1.7",
+  "version": "3.2.0",
   "description": "Official living style guide app and component library for egghead.io",
   "homepage": "https://github.com/eggheadio/egghead-ui#readme",
   "main": "lib/index.js",

--- a/src/components/Request/index.js
+++ b/src/components/Request/index.js
@@ -135,9 +135,8 @@ Request.propTypes = {
   subscribeInterval: PropTypes.number,
 }
 
-
 Request.defaultProps = {
   method: first(methods),
   subscribe: false,
-  subscribeInterval: 10000,
+  subscribeInterval: 5000,
 }

--- a/src/components/Request/index.js
+++ b/src/components/Request/index.js
@@ -24,11 +24,6 @@ export default class Request extends Component {
     subscription: null,
   }
 
-  subscribeAction = () => {
-    console.log('subscribe hit')
-  }
-
-
   componentDidMount() {
     const {lazy, subscribe, subscribeInterval} = this.props
     if (!lazy) {

--- a/src/components/Request/index.js
+++ b/src/components/Request/index.js
@@ -29,7 +29,12 @@ export default class Request extends Component {
       this.request()
       if (subscribe) {
         this.setState({
-          subscription: window.setInterval(this.request, subscribeInterval)
+          subscription: window.setInterval(() => {
+            const {running} = this.state
+            if(!running) {
+              this.request()
+            }
+          }, subscribeInterval)
         })
       }
     }

--- a/src/components/Request/index.js
+++ b/src/components/Request/index.js
@@ -17,7 +17,6 @@ export default class Request extends Component {
 
   state = {
     running: !this.props.lazy,
-    hasRunOnce: false,
     response: null,
     data: null,
     error: null,
@@ -60,7 +59,6 @@ export default class Request extends Component {
           }
           this.setState({
             running: false,
-            hasRunOnce: true,
             response,
             data: response.data,
             error: null,
@@ -79,7 +77,6 @@ export default class Request extends Component {
           }
           this.setState({
             running: false,
-            hasRunOnce: true,
             response: error,
             error,
           }, () => {
@@ -96,11 +93,11 @@ export default class Request extends Component {
 
   render() {
     const {children, lazy} = this.props
-    const {running, hasRunOnce, error, data, response} = this.state
+    const {running, error, data, response} = this.state
     if (!children) {
       return null
     }
-    if (running && (lazy || !hasRunOnce)) {
+    if (running && (lazy || !data)) {
       return <Loading />
     }
     if (error) {

--- a/src/components/Request/index.js
+++ b/src/components/Request/index.js
@@ -135,5 +135,5 @@ Request.propTypes = {
 Request.defaultProps = {
   method: first(methods),
   subscribe: false,
-  subscribeInterval: 5000,
+  subscribeInterval: 10000,
 }


### PR DESCRIPTION
# Changes

- Add `subscription` (polling) option for non-lazy `Request`s
- `Request` already has a callback (`onResponse` handler). This works well for now. It is a bit slower than a server push-based model or client-side only updates with a state management sytem, but it is simpler. If this becomes a problem, I'd recommend we upgrade to GraphQL (most likely with Relay) as it doesn't seem very difficult and has huge wins (maintains caching, requests etc. for you with declarative data fetching syntax inside the component that needs it); this seems to be a much better solution to state and data than Redux or MobX to me if/when the time comes.
- Version bump for new npm release

# Result For User

See example use in Instructor Center: https://github.com/eggheadio/egghead-instructor-center/pull/167

---

![](https://img.buzzfeed.com/buzzfeed-static/static/2014-07/18/8/enhanced/webdr08/anigif_enhanced-buzz-8915-1405685312-10.gif)