### PR TITLE
Promote List component from egghead-instructor-center (resolve #73)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Official living style guide app and component library for egghead.io",
   "homepage": "https://github.com/eggheadio/egghead-ui#readme",
   "main": "lib/index.js",

--- a/src/components/List/index.examples.js
+++ b/src/components/List/index.examples.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import {storiesOf} from '@kadira/storybook'
+import {NodeFixture} from '../../utils/fixtures'
+import List from '.'
+
+const exampleItems = [
+  NodeFixture, 
+  NodeFixture,
+  NodeFixture,
+]
+
+storiesOf('List')
+  .addWithInfo(
+    'Info',
+    'Used to display a list of items',
+    () => (
+      <List items={exampleItems} />
+    ),
+  )
+  .addWithPropsCombinations(
+    'Combinations',
+    List, 
+    {
+      items: [exampleItems],
+    },
+  )

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -1,0 +1,21 @@
+import React, {PropTypes} from 'react'
+import {map} from 'lodash'
+
+const List = ({items}) => (
+  <div>
+    {map(items, (item, index) => (
+      <div
+        key={index}
+        className={`pa4 ${index < items.length - 1 ? 'bb b--light-gray' : ''}`}
+      >
+        {item}
+      </div>
+    ))}
+  </div>
+)
+
+List.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.node).isRequired,
+}
+
+export default List

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import ErrorSource from './components/Error'
 import HeadingSource from './components/Heading'
 import IconSource from './components/Icon'
 import InputSource from './components/Input'
+import ListSource from './components/List'
 import MarkdownSource from './components/Markdown'
 import ParagraphSource from './components/Paragraph'
 import RadioGroupSource from './components/RadioGroup'
@@ -19,6 +20,7 @@ export const Error = ErrorSource
 export const Heading = HeadingSource
 export const Icon = IconSource
 export const Input = InputSource
+export const List = ListSource
 export const Markdown = MarkdownSource
 export const Paragraph = ParagraphSource
 export const RadioGroup = RadioGroupSource


### PR DESCRIPTION
# Changes

- Promote List (component for rendering a list of items, it just adds a bottom light gray border to each item but the last, and adds padding around each item)
- Add List examples
- Version bump

# Result For User

## Info

<img width="821" alt="screen shot 2017-03-22 at 2 16 35 pm" src="https://cloud.githubusercontent.com/assets/5497885/24218933/b4242168-0f0a-11e7-930f-bca5a46878bd.png">


## Examples

Currently no different than `Info` but I wired it up so if/when props change the possible prop combinations will render as well, automatically from the prop options.

<img width="783" alt="screen shot 2017-03-22 at 2 17 10 pm" src="https://cloud.githubusercontent.com/assets/5497885/24218934/b425dba2-0f0a-11e7-800a-f150aa78079b.png">

---

![](https://media.giphy.com/media/Qw3UKXehdETjq/giphy.gif)