### PR TITLE
Improve console output for consuming projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Components used across egghead projects",
   "scripts": {
     "dev:styleguide": "start-storybook -p 2000",

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -69,8 +69,10 @@ const StyledButton = styled(({
   )
 })`${props => styleMap(props.size)}`
 
+StyledButton.displayName = 'Button'
+
 StyledButton.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   href: PropTypes.string,
   onClick: PropTypes.func,
   color: PropTypes.oneOf(colors),

--- a/src/components/Error/index.js
+++ b/src/components/Error/index.js
@@ -15,7 +15,7 @@ const Error = ({children}) => (
 )
 
 Error.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 }
 
 export default Error

--- a/src/components/Loading/index.js
+++ b/src/components/Loading/index.js
@@ -15,6 +15,8 @@ const Rotate = styled.div`
   animation: ${rotate360} 1.5s linear infinite;
 `;
 
+Rotate.displayName = 'Rotate'
+
 const Loading = () => (
   <div className='orange flex items-center'>
     <div className='mr2'>

--- a/src/components/Paragraph/index.js
+++ b/src/components/Paragraph/index.js
@@ -20,7 +20,7 @@ const Paragraph = ({
 )
 
 Paragraph.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   type: PropTypes.oneOf(types),
 }
 


### PR DESCRIPTION
# Changes

- Change some `string` proptypes to `node` [to allow localization `Text` passing](https://github.com/eggheadio/egghead-instructor-center/issues/135)
- Add `displayName` to `styled-component` instances to get an actual component name in errors instead of `Styled(Component)`

<img width="1017" alt="screen shot 2017-03-24 at 11 17 49 am" src="https://cloud.githubusercontent.com/assets/5497885/24306748/4579fc82-1087-11e7-8475-a5ddade2bc1d.png">

# Result For User

- Can pass localized text elements or strings to things that accept strings
- Display names on styled-components in console

---

![](https://media.giphy.com/media/Zr3fBawA5XQGc/giphy.gif)