### PR TITLE
Add plain build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Components used across egghead projects",
   "scripts": {
     "dev:package": "yarn build:package -- -w",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "verify": "CI=true yarn test && yarn lint && yarn build:package && yarn build:app",
     "bump": "yarn version && git push && git push --tags",
     "prepublish": "yarn build:package",
+    "build": "yarn build:app",
     "start": "NODE_PATH=./src react-scripts start"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
It seems that the CRA heroku buildpack needs a "build" script now, not sure why it worked before, but we'll see if this works

<img width="689" alt="screen shot 2017-04-21 at 12 33 00 pm" src="https://cloud.githubusercontent.com/assets/5497885/25291387/106ac1de-268f-11e7-9c03-dabe2998219b.png">
