### PR TITLE
Polish LessonActions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "5.1.2",
+  "version": "5.2.0",
   "description": "Components used across egghead projects",
   "scripts": {
     "dev:package": "yarn build:package -- -w",

--- a/src/App/components/Resource/components/Examples/index.js
+++ b/src/App/components/Resource/components/Examples/index.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react'
 import {map, includes, size, uniqueId} from 'lodash'
 import {
+  xsmallContainerWidth,
   smallContainerWidth,
   mediumContainerWidth,
   largeContainerWidth,
@@ -11,6 +12,10 @@ import Heading from 'package/components/Heading'
 import Button from 'package/components/Button'
 
 const containerWidthActions = [
+  {
+    label: 'XSmall',
+    containerWidth: xsmallContainerWidth,
+  },
   {
     label: 'Small',
     containerWidth: smallContainerWidth,
@@ -55,7 +60,7 @@ export const optOuts = [
 class Examples extends Component {
 
   state = {
-    containerWidth: smallContainerWidth,
+    containerWidth: xsmallContainerWidth,
     containerBackground: 'dark',
     examples: false,
   }

--- a/src/App/utils/resourcesByType/index.js
+++ b/src/App/utils/resourcesByType/index.js
@@ -30,6 +30,7 @@ import Request, {methods as requestMethods} from 'package/components/Request'
 import RequestedLessons from 'package/components/RequestedLessons'
 import Tabs from 'package/components/Tabs'
 import Toggle, {selectedItems as toggleSelectedItems} from 'package/components/Toggle'
+import ViewportWidth from 'package/components/ViewportWidth'
 
 import InstructorDashboard from 'package/screens/InstructorDashboard'
 import InstructorDetails from 'package/screens/InstructorDetails'
@@ -717,6 +718,23 @@ export const resourcesByType = {
             selectedItem={random.arrayElement(toggleSelectedItems)}
           />,
         ],
+      },
+
+      ViewportWidth: {
+        useCase: `Used to get the current browser width. ContainerWidth is preferred in most situations unless the entire viewport width is needed.`,
+        types: {
+          'children*': 'func',
+          'onWidthChange': 'func',
+        },
+        childrenTypes: {
+          'isLikelyDesktop': 'bool',
+        },
+        createExamples: () => [
+          <ViewportWidth>
+            {(isLikelyDesktop) => <div>isLikelyDesktop: {`${isLikelyDesktop}`}</div>}
+          </ViewportWidth>,
+        ],
+        optOut: ['types', 'containerBackground'],
       },
 
     }

--- a/src/package/components/ContainerWidth/index.js
+++ b/src/package/components/ContainerWidth/index.js
@@ -1,13 +1,14 @@
 import React, {PropTypes, Component} from 'react'
 import elementResizeEvent, {unbind} from 'element-resize-event'
 import {
+  smallContainerWidth,
   mediumContainerWidth,
   largeContainerWidth,
   xlargeContainerWidth,
   xxlargeContainerWidth,
 } from 'package/utils/hardCodedSizes'
 
-export default class DeviceWidth extends Component {
+export default class ContainerWidth extends Component {
   
   state = {
     containerWidth: 'small',
@@ -48,25 +49,33 @@ export default class DeviceWidth extends Component {
         containerWidth: 'medium',
       })
     }
-    else {
+    else if (containerExactWidth >= smallContainerWidth) {
       this.setState({
         containerWidth: 'small',
+      })
+    }
+    else {
+      this.setState({
+        containerWidth: 'xsmall',
       })
     }
   }
 
   render() {
     const {containerWidth} = this.state
-    const {children} = this.props
+    const {children, className} = this.props
     return (
-      <div ref='container'>
+      <div 
+        ref='container'
+        className={className}
+      >
         {children(containerWidth)}
       </div>
     )
   }
 }
 
-DeviceWidth.propTypes = {
+ContainerWidth.propTypes = {
   children: PropTypes.func.isRequired,
   onWidthChange: PropTypes.func,
 }

--- a/src/package/components/LayoutColumns/index.js
+++ b/src/package/components/LayoutColumns/index.js
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react'
 import {map} from 'lodash'
-import {smallContainerWidth} from 'package/utils/hardCodedSizes'
+import {xsmallContainerWidth} from 'package/utils/hardCodedSizes'
 
 const LayoutColumns = ({items, relativeSizes}) => (
   <div className='flex flex-wrap'>
@@ -16,7 +16,7 @@ const LayoutColumns = ({items, relativeSizes}) => (
             ? relativeSizes[index]
             : 1,
           flexShrink: 0,
-          flexBasis: smallContainerWidth - 100,
+          flexBasis: xsmallContainerWidth - 100,
         }}
       >
         {item}

--- a/src/package/components/LessonActions/components/LessonAction/index.js
+++ b/src/package/components/LessonActions/components/LessonAction/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import ContainerWidth from 'package/components/ContainerWidth'
 import Icon from 'package/components/Icon'
 
 export default ({
@@ -8,17 +9,23 @@ export default ({
   url, 
   onClick,
 }) => (
-  <a
-    href={url}
-    onClick={onClick}
-    className='pa4 flex flex-column tc items-center dark-gray no-underline pointer dim'
-  >
-    <Icon
-      type={iconType}
-      color={color}
-    />
-    <div className='pt3 b'>
-      {actionText}
-    </div>
-  </a>
+  <ContainerWidth>
+    {(containerWidth) => (
+      <a
+        href={url}
+        onClick={onClick}
+        className='pa3 tc flex flex-wrap items-center justify-center h-100 dark-gray no-underline pointer dim'
+    >
+        <div className='pa2'>
+          <Icon
+            type={iconType}
+            color={color}
+          />
+        </div>
+        <div className='b f6 fw5'>
+          {actionText}
+        </div>
+      </a>
+    )}
+  </ContainerWidth>
 )

--- a/src/package/components/LessonActions/index.js
+++ b/src/package/components/LessonActions/index.js
@@ -2,6 +2,8 @@ import React, {PropTypes} from 'react'
 import {map, keys, compact} from 'lodash'
 import {lessonStateVerbToPastTense, detailsByLessonState} from 'package/utils/lessonStates'
 import Request from 'package/components/Request'
+import ViewportWidth from 'package/components/ViewportWidth'
+import ContainerWidth from 'package/components/ContainerWidth'
 import LessonAction from './components/LessonAction'
 
 const stateVerbs = keys(lessonStateVerbToPastTense)
@@ -12,9 +14,9 @@ const LessonActions = ({
   requestCurrentPage,
 }) => {
 
-  const items = compact([
+  const getItems = (isLikelyDesktop) => compact([
 
-    lesson.upload_lesson_http_url
+    isLikelyDesktop && lesson.upload_lesson_http_url
       ? <LessonAction
           actionText={lesson.wistia_id
             ? 'Replace Video'
@@ -61,25 +63,42 @@ const LessonActions = ({
   ])
 
   return (
-    <div className='flex flex-wrap items-stretch justify-end h-100'>
-      {map(items, (item, index) => (
-        <div 
-          key={index}
-          className={`
-            flex
-            items-center
-            justify-center
-            mw4
-            bl b--gray-secondary
-          `}
-          style={{
-            flex: `1 0 115px`,
-          }}
-        >
-          {item}
-        </div>
-      ))}
-    </div>
+    <ViewportWidth>
+      {(isLikelyDesktop) => (
+        <ContainerWidth className='h-100'>
+          {(containerWidth) => (
+            <div className={`
+              h-100
+              ${containerWidth === 'xsmall'
+                ? ''
+                : 'flex flex-wrap justify-end'
+              }
+            `}>
+              {map(getItems(isLikelyDesktop), (item, index) => (
+                <div 
+                  key={index}
+                  className={`
+                    flex
+                    items-center
+                    ${containerWidth === 'xsmall'
+                      ? index === 0 ? '' : 'bt b--gray-secondary'
+                      : index === 0 ? '' : 'bl b--gray-secondary justify-center'
+                    }
+                  `}
+                  style={{
+                    flexGrow: 0,
+                    flexShrink: 0,
+                    flexBasis: 90,
+                  }}
+                >
+                  {item}
+                </div>
+              ))}
+            </div>
+          )}
+        </ContainerWidth>
+      )}
+    </ViewportWidth>
   )
 }
 

--- a/src/package/components/LessonOverviews/components/PaginatedLessonOverviews/components/LessonOverview/index.js
+++ b/src/package/components/LessonOverviews/components/PaginatedLessonOverviews/components/LessonOverview/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
 import {detailsByLessonState} from 'package/utils/lessonStates'
-import {smallContainerWidth} from 'package/utils/hardCodedSizes'
+import {xsmallContainerWidth} from 'package/utils/hardCodedSizes'
 import Maybe from 'package/components/Maybe'
 import Heading from 'package/components/Heading'
 import Image from 'package/components/Image'
@@ -16,7 +16,7 @@ export default ({lesson, requestCurrentPage}) => (
       style={{
         flexGrow: 1,
         flexShrink: 0,
-        flexBasis: smallContainerWidth,
+        flexBasis: xsmallContainerWidth,
       }}
     >
 
@@ -71,7 +71,7 @@ export default ({lesson, requestCurrentPage}) => (
     <div style={{
       flexGrow: 1,
       flexShrink: 0,
-      flexBasis: smallContainerWidth,
+      flexBasis: xsmallContainerWidth,
     }}>
       <LessonActions 
         lesson={lesson} 

--- a/src/package/components/ViewportWidth/index.js
+++ b/src/package/components/ViewportWidth/index.js
@@ -1,0 +1,48 @@
+import {PropTypes, Component} from 'react'
+import {likelyDesktopViewportWidth} from 'package/utils/hardCodedSizes'
+
+class ViewportWidth extends Component {
+  
+  state = {
+    isLikelyDesktop: false,
+  }
+
+  componentDidMount = () => {
+    this.handleWidthChange()
+    window.onresize = this.handleWidthChange
+  }
+
+  componentWillUnmount = () => {
+    window.onresize = null
+  }
+
+  handleWidthChange = () => {
+    const {onWidthChange} = this.props
+    if(onWidthChange) {
+      onWidthChange()
+    }
+    if(window.innerWidth >= likelyDesktopViewportWidth) {
+      this.setState({
+        isLikelyDesktop: true,
+      })
+    }
+    else {
+      this.setState({
+        isLikelyDesktop: false,
+      })
+    }
+  }
+
+  render() {
+    const {isLikelyDesktop} = this.state
+    const {children} = this.props
+    return children(isLikelyDesktop)
+  }
+}
+
+ViewportWidth.propTypes = {
+  children: PropTypes.func.isRequired,
+  onWidthChange: PropTypes.func,
+}
+
+export default ViewportWidth

--- a/src/package/utils/hardCodedSizes/index.js
+++ b/src/package/utils/hardCodedSizes/index.js
@@ -1,13 +1,17 @@
-export const smallContainerWidth = 320
+export const xsmallContainerWidth = 320
+export const smallContainerWidth = 450
 export const mediumContainerWidth = 640
 export const largeContainerWidth = 992
 export const xlargeContainerWidth = 1300
 export const xxlargeContainerWidth = 1700
 
 export const containerWidths = [
+  'xsmall',
   'small',
   'medium',
   'large',
   'xlarge',
   'xxlarge',
 ]
+
+export const likelyDesktopViewportWidth = 1200


### PR DESCRIPTION
# Changes

- Polish `LessonActions` to match mock
- Add container-query esque styles to `LessonActions` so they work well in all container sizes
- Add extra small container width
- Add `ViewportWidth` component to watch the viewport/browser width and determine if the user is likely on desktop for certain features
- Add `ViewportWidth` example/documentation
- Use `ViewportWidth` in lesson actions, to only display the upload/replace video action when the user is likely on desktop (over 1200px viewport width)
- Minor version bump

# Result For User

This shows how the `LessonActions` styles change by the container's width:

![responsive-lesson-actions](https://cloud.githubusercontent.com/assets/5497885/25504643/fc79694c-2b5b-11e7-9fbd-7ef48784746f.gif)

This shows the new `ViewportWidth` component (how it is different than `ContainerWidth`) and it's use in `LessonActions` to only display the upload/replace video option when likely on desktop, not related to the container width.

![desktop-features](https://cloud.githubusercontent.com/assets/5497885/25504665/0adaad0c-2b5c-11e7-9512-20dd16c56640.gif)


---

![](https://media3.giphy.com/media/DDpI5Wre5CiLS/giphy.gif)