### PR TITLE
Export ViewportContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Components used across egghead projects",
   "scripts": {
     "dev:package": "yarn build:package -- -w",

--- a/src/package/index.js
+++ b/src/package/index.js
@@ -27,6 +27,7 @@ import RequestSource from 'package/components/Request'
 import RequestedLessonsSource from 'package/components/RequestedLessons'
 import TabsSource from 'package/components/Tabs'
 import ToggleSource from 'package/components/Toggle'
+import ViewportContainerSource from 'package/components/ViewportContainer'
 
 import InstructorDashboardSource from 'package/screens/InstructorDashboard'
 import InstructorDetailsSource from 'package/screens/InstructorDetails'
@@ -69,6 +70,7 @@ export const Request = RequestSource
 export const RequestedLessons = RequestedLessonsSource
 export const Tabs = TabsSource
 export const Toggle = ToggleSource
+export const ViewportContainer = ViewportContainerSource
 
 export const InstructorDashboard = InstructorDashboardSource
 export const NewLesson = NewLessonSource


### PR DESCRIPTION
Would be good to automate this in the future so the package index exports a glob of `package/*/index.js`