### PR TITLE
Polish List

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "6.1.4",
+  "version": "6.2.0",
   "description": "Components used across egghead projects",
   "scripts": {
     "dev:package": "yarn build:package -- -w",

--- a/src/App/utils/resourcesByType/index.js
+++ b/src/App/utils/resourcesByType/index.js
@@ -19,7 +19,7 @@ import LayoutColumns from 'package/components/LayoutColumns'
 import LessonActions from 'package/components/LessonActions'
 import LessonOverviews from 'package/components/LessonOverviews'
 import LessonOverviewsByGroup from 'package/components/LessonOverviewsByGroup'
-import List from 'package/components/List'
+import List, {sizes as listSizes} from 'package/components/List'
 import Loading from 'package/components/Loading'
 import Markdown from 'package/components/Markdown'
 import Maybe from 'package/components/Maybe'
@@ -72,16 +72,6 @@ const createNodeExample = () => random.arrayElement([
     <IconLabel
       iconType='check'
       labelText={lorem.words()}
-    />
-  </div>,
-
-  <div>
-    <Heading level='3'>
-      {lorem.words()}
-    </Heading>
-    <Toggle
-      leftOption={lorem.word()}
-      rightOption={lorem.word()}
     />
   </div>,
 
@@ -480,6 +470,8 @@ export const resourcesByType = {
         useCase: `Used to show a collection of nodes in a vertical stack.`,
         types: {
           'items*': '[node]',
+          'size': listSizes,
+          'overDark': 'bool',
         },
         createExamples: () => [
           <List items={[
@@ -489,6 +481,15 @@ export const resourcesByType = {
             createNodeExample(),
             createNodeExample(),
           ]} />,
+          <List 
+            items={[
+              createNodeExample(),
+              createNodeExample(),
+              createNodeExample(),
+            ]} 
+            size={random.arrayElement(listSizes)}
+            overDark={random.boolean()}
+          />,
         ]
       },
 

--- a/src/App/utils/resourcesByType/index.js
+++ b/src/App/utils/resourcesByType/index.js
@@ -158,6 +158,7 @@ export const resourcesByType = {
           'size': buttonSizes,
           'color': colors,
           'outline': 'bool',
+          'overDark': 'bool',
         },
         createExamples: () => [
           <Button>

--- a/src/package/components/Heading/index.js
+++ b/src/package/components/Heading/index.js
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react'
+import ContainerWidth from 'package/components/ContainerWidth'
 
 export const levels = ['1', '2', '3', '4', '5']
 
@@ -6,57 +7,56 @@ const sharedStyle = {
   wordBreak: 'break-word',
 }
 
-const Heading = ({children, level}) => {
-
-  const outputByLevel = {
-    1: (
-      <h1 
-        className='mt0 normal f1 mb4'
-        style={sharedStyle}
-      >
-        {children}
-      </h1>
-    ),
-    2: (
-      <h2 
-        className='mt0 normal f2 mb3'
-        style={sharedStyle}
-      >
-        {children}
-      </h2>
-    ),
-    3: (
-      <h3 
-        className='mt0 bold f3 mb2'
-        style={sharedStyle}
-      >
-        {children}
-      </h3>
-    ),
-    4: (
-      <h4 
-        className='mt0 normal f4 mb2'
-        style={sharedStyle}
-      >
-        {children}
-      </h4>
-    ),
-    5: (
-      <h5 
-        className='mt0 bold f5 mb2'
-        style={sharedStyle}
-      >
-        {children}
-      </h5>
-    ),
-  }
-
-  return (
-    <div>
-      {outputByLevel[level]}
-    </div>
-  )
-}
+const Heading = ({children, level}) => (
+  <ContainerWidth> 
+    {(containerWidth) => (
+      <div>
+        {{
+          1: (
+            <h1 
+              className={`${containerWidth === 'xsmall' ? 'f3' : 'f1'} mt0 normal mb4`}
+              style={sharedStyle}
+            >
+              {children}
+            </h1>
+          ),
+          2: (
+            <h2 
+              className={`${containerWidth === 'xsmall' ? 'f4 bold' : 'f2 normal'} mt0 mb3`}
+              style={sharedStyle}
+            >
+              {children}
+            </h2>
+          ),
+          3: (
+            <h3 
+              className={`${containerWidth === 'xsmall' ? 'f5 bold' : 'f3 normal'} mt0 mb2`}
+              style={sharedStyle}
+            >
+              {children}
+            </h3>
+          ),
+          4: (
+            <h4 
+              className={`${containerWidth === 'xsmall' ? 'f5 bold' : 'f4 normal'} mt0 mb2`}
+              style={sharedStyle}
+            >
+              {children}
+            </h4>
+          ),
+          5: (
+            <h5 
+              className='f5 bold mt0 mb2'
+              style={sharedStyle}
+            >
+              {children}
+            </h5>
+          ),
+        }[level]}
+      </div>
+    )}
+  </ContainerWidth>
+)
 
 Heading.propTypes = {
   children: PropTypes.string.isRequired,

--- a/src/package/components/LessonOverviews/components/PaginatedLessonOverviews/components/LessonOverview/index.js
+++ b/src/package/components/LessonOverviews/components/PaginatedLessonOverviews/components/LessonOverview/index.js
@@ -16,7 +16,7 @@ export default ({lesson, requestCurrentPage}) => (
       style={{
         flexGrow: 1,
         flexShrink: 0,
-        flexBasis: xsmallContainerWidth,
+        flexBasis: xsmallContainerWidth - 100,
       }}
     >
 
@@ -26,7 +26,7 @@ export default ({lesson, requestCurrentPage}) => (
         className='w2 h2 mr3'
       />
 
-      <div>
+      <div className='w-100'>
 
         <div className='mb3 ttu b'>
           {detailsByLessonState[lesson.state].title || lesson.state}
@@ -34,10 +34,7 @@ export default ({lesson, requestCurrentPage}) => (
 
         <Link 
           to={`/lessons/${lesson.slug}`}
-          className='pointer dim no-underline base'
-          style={{
-            wordBreak: 'break-word',
-          }}
+          className='db pointer dim no-underline base'
         >
           <Heading level='3'>
             {lesson.title}
@@ -71,7 +68,7 @@ export default ({lesson, requestCurrentPage}) => (
     <div style={{
       flexGrow: 1,
       flexShrink: 0,
-      flexBasis: xsmallContainerWidth,
+      flexBasis: xsmallContainerWidth - 100,
     }}>
       <LessonActions 
         lesson={lesson} 

--- a/src/package/components/List/index.js
+++ b/src/package/components/List/index.js
@@ -1,12 +1,32 @@
 import React, {PropTypes} from 'react'
-import {map} from 'lodash'
+import {map, keys} from 'lodash'
 
-const List = ({items}) => (
+const paddingClassNameBySize = {
+  small: 'pa3',
+  medium: 'pa4',
+  large: 'pa5',
+}
+
+export const sizes = keys(paddingClassNameBySize)
+
+const List = ({
+  items, 
+  size = 'medium',
+  overDark = false,
+}) => (
   <div>
     {map(items, (item, index) => (
       <div
         key={index}
-        className={`pa4 ${index < items.length - 1 ? 'bb b--gray-secondary' : ''}`}
+        className={`
+          ${paddingClassNameBySize[size]} 
+          ${index < items.length - 1 
+            ? overDark
+              ? 'bb b--dark-blue'
+              : 'bb b--gray-secondary' 
+            : ''
+          }
+        `}
       >
         {item}
       </div>
@@ -16,6 +36,8 @@ const List = ({items}) => (
 
 List.propTypes = {
   items: PropTypes.arrayOf(PropTypes.node).isRequired,
+  size: PropTypes.oneOf(sizes),
+  overDark: PropTypes.bool,
 }
 
 export default List


### PR DESCRIPTION
# Changes

- Add `size` to `List`, can be `small`, `medium`, or `large` - defaults to `medium`
- Add `overDark` to `List`, which changes the item border color
- Update list examples/documentation
- Add some container-width based styles to headings and lesson overviews

# Result For User

## overDark List option

![image](https://cloud.githubusercontent.com/assets/5497885/25596373/0cdf3e88-2e86-11e7-81a9-1ac4113e07c0.png)

## `small` size List option (default)

![image](https://cloud.githubusercontent.com/assets/5497885/25596438/52421388-2e86-11e7-99ab-532f3cd5cb49.png)

## `medium` size List option (default)

![image](https://cloud.githubusercontent.com/assets/5497885/25596412/378010ae-2e86-11e7-9b0d-6fa52ede6548.png)

## `large` size List option

![image](https://cloud.githubusercontent.com/assets/5497885/25596393/2a1eadbc-2e86-11e7-8a35-3298c30b717f.png)

## Updated container width styles for heading and lesson overviews:

<img width="1202" alt="screen shot 2017-05-01 at 2 54 31 pm" src="https://cloud.githubusercontent.com/assets/5497885/25596212/5388dd0e-2e85-11e7-9d1c-5e1a13588395.png">
<img width="1061" alt="screen shot 2017-05-01 at 2 54 21 pm" src="https://cloud.githubusercontent.com/assets/5497885/25596214/538cff9c-2e85-11e7-9b00-e72309c8cbb1.png">

---

![](https://media3.giphy.com/media/B37cYPCruqwwg/giphy.gif)