### PR TITLE
Quick fix for auth issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egghead-ui",
-  "version": "6.9.0",
+  "version": "7.0.0",
   "description": "Components used across egghead projects",
   "homepage": "https://styleguide.egghead.io",
   "engines": {

--- a/src/package/components/Request/index.js
+++ b/src/package/components/Request/index.js
@@ -17,16 +17,23 @@ export const methods = [
 
 class Request extends Component {
 
-  getHeaders = () => ({
-    ...this.props.headers,
-    Authorization: universalWindow.localStorage.token
-      ? `Bearer ${universalWindow.localStorage.token}`
-      : null,
-    'Content-Type': 'application/json',
-  })
+  getHeaders = () => {
+    const headers = {...this.props.headers}
+    if (this.props.auth) {
+      return {
+        ...headers,
+        Authorization: universalWindow.localStorage.token
+          ? `Bearer ${universalWindow.localStorage.token}`
+          : null,
+        'Content-Type': 'application/json',
+      }
+    }
+
+    return headers
+  }
 
   handleError = (error) => {
-    if (includes([401, 403], error.response.status)) {
+    if (includes([401, 403], error.response.status) && this.props.auth) {
       logout()
     }
     if (this.props.onError) {
@@ -61,6 +68,7 @@ Request.propTypes = {
   children: PropTypes.func.isRequired,
   url: PropTypes.string.isRequired,
   lazy: PropTypes.bool,
+  auth: PropTypes.bool,
   placeholder: PropTypes.node,
   params: PropTypes.object,
   headers: PropTypes.object,
@@ -76,6 +84,7 @@ Request.propTypes = {
 Request.defaultProps = {
   method: first(methods),
   subscribe: false,
+  auth: false,
   subscribeInterval: 10000,
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4578,9 +4578,9 @@ react-icon-base@^2.0.7:
   dependencies:
     prop-types "15.5.8"
 
-"react-icons@github:eggheadio/react-icons#3.5.0":
-  version "3.5.0"
-  resolved "https://codeload.github.com/eggheadio/react-icons/tar.gz/5d3ca77b3cc9fed6b90a7bc5b90299c46ffe8de2"
+"react-icons@github:eggheadio/react-icons#3.6.0":
+  version "3.6.0"
+  resolved "https://codeload.github.com/eggheadio/react-icons/tar.gz/9eaf3214396abf8cdb4041da188b1246b1f067ca"
   dependencies:
     react "^15.0.0"
     react-dom "^15.0.0"


### PR DESCRIPTION
bumping to 7.0.0 since this is breaking, just added a property to fix the auth header issue with the `Request` component.
![image](https://media2.giphy.com/media/pXIOZAJUkRRGE/giphy.gif?response_id=591e5d7666d5d61f2d4b9719)
